### PR TITLE
Fix README usage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requirements:
 ## 🧪 Usage
 
 ```bash
-python onionscan.py http://somedomain.onion --timeout 15 --output scan.json
+python main.py http://somedomain.onion --timeout 15 --output scan.json
 ```
 
 Options:


### PR DESCRIPTION
## Summary
- update README to use `python main.py` instead of `python onionscan.py`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_684887370644832186ce1148de633100