### PR TITLE
Improve test suite coverage

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,12 +9,12 @@ import hashlib
 from io import BytesIO
 from urllib.parse import urlparse, urljoin
 
+from functools import lru_cache
 import requests
 from PIL import Image, UnidentifiedImageError
 from bs4 import BeautifulSoup
 import stem
 import stem.descriptor.remote
-from functools import lru_cache
 
 _TOR_SESSION = None
 
@@ -22,7 +22,7 @@ _TOR_SESSION = None
 def get_tor_session():
     """Return a requests session configured to use the Tor SOCKS proxy."""
 
-    global _TOR_SESSION
+    global _TOR_SESSION  # pylint: disable=global-statement
     if _TOR_SESSION is None:
         host = os.getenv("TOR_PROXY_HOST", "127.0.0.1")
         port = os.getenv("TOR_PROXY_PORT", "9050")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,95 @@
+"""Tests for core module utilities."""
+
+import main
+
+
+def test_get_tor_session_singleton(monkeypatch):
+    """Verify get_tor_session returns a cached session."""
+    calls = []
+
+    class FakeSession:  # pylint: disable=too-few-public-methods
+        """Minimal session mock."""
+
+        def __init__(self):
+            calls.append(1)
+            self.proxies = {}
+            self.headers = {}
+
+    def fake_session():
+        return FakeSession()
+
+    monkeypatch.setattr(main.requests, "Session", fake_session)
+    monkeypatch.setenv("TOR_PROXY_HOST", "host")
+    monkeypatch.setenv("TOR_PROXY_PORT", "1234")
+    main._TOR_SESSION = None  # pylint: disable=protected-access
+
+    s1 = main.get_tor_session()
+    s2 = main.get_tor_session()
+
+    assert s1 is s2
+    assert s1.proxies["http"] == "socks5h://host:1234"
+    assert len(calls) == 1
+
+
+def test_check_common_files(monkeypatch):
+    """Check that known files are detected properly."""
+
+    class Resp:  # pylint: disable=too-few-public-methods
+        """Simple response object."""
+
+        def __init__(self, code):
+            self.status_code = code
+
+    class FakeSession:  # pylint: disable=too-few-public-methods
+        """Collects requested URLs."""
+
+        def __init__(self):
+            self.requested = []
+
+        def get(self, url, timeout=10):  # pylint: disable=unused-argument
+            """Record URL and return fake response."""
+            self.requested.append(url)
+            if url.endswith("/admin"):
+                return Resp(200)
+            return Resp(404)
+
+    def fake_get_session():
+        return FakeSession()
+
+    monkeypatch.setattr(main, "get_tor_session", fake_get_session)
+
+    findings = main.check_common_files("http://x.onion")
+    assert {"path": "/admin", "status": 200} in findings
+
+
+def test_extract_exif_data_from_images(monkeypatch):
+    """Ensure EXIF data is extracted from images."""
+    html = "<img src='img.png'>"
+
+    class FakeSession:  # pylint: disable=too-few-public-methods
+        """Session returning an image."""
+
+        def get(self, _url, timeout=5):  # pylint: disable=unused-argument
+            """Return a bytes response."""
+
+            class R:  # pylint: disable=too-few-public-methods
+                """Response placeholder."""
+
+                content = b"bytes"
+
+            return R()
+
+    fake_img = type("Img", (), {"getexif": lambda self: {1: 2}})()
+
+    def fake_get_session():
+        return FakeSession()
+
+    monkeypatch.setattr(main, "get_tor_session", fake_get_session)
+
+    def fake_open(*_args, **_kwargs):
+        return fake_img
+
+    monkeypatch.setattr(main.Image, "open", fake_open)
+
+    result = main.extract_exif_data_from_images(html, "http://a.onion")
+    assert result == [{"src": "http://a.onion/img.png", "exif": {1: 2}}]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,50 +1,57 @@
-import pytest
+"""Tests for HTML extraction helpers."""
+
 from main import (
     html_fingerprint,
     extract_onion_links,
     extract_bitcoin_addresses,
     extract_pgp_keys,
     extract_emails_and_ids,
-    extract_metadata
+    extract_metadata,
 )
 
 
 def test_html_fingerprint():
-    html = '<html><body>Hello World</body></html>'
-    expected = 'd54b7b623983de5b6880519382f60059f00539d4'
+    """SHA1 fingerprint should match expected hash."""
+    html = "<html><body>Hello World</body></html>"
+    expected = "d54b7b623983de5b6880519382f60059f00539d4"
     assert html_fingerprint(html) == expected
 
 
 def test_extract_onion_links():
+    """Only .onion links should be returned."""
     html = '<a href="http://abc.onion/page">link</a><a href="https://example.com">x</a>'
     links = extract_onion_links(html)
-    assert links == ['http://abc.onion/page']
+    assert links == ["http://abc.onion/page"]
 
 
 def test_extract_bitcoin_addresses():
-    html = 'Donate: 1BoatSLRHtKNngkdXEeobR76b53LETtpyT and 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+    """Bitcoin addresses are detected in text."""
+    html = "Donate: 1BoatSLRHtKNngkdXEeobR76b53LETtpyT and 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"
     addrs = extract_bitcoin_addresses(html)
-    assert '1BoatSLRHtKNngkdXEeobR76b53LETtpyT' in addrs
-    assert '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy' in addrs
+    assert "1BoatSLRHtKNngkdXEeobR76b53LETtpyT" in addrs
+    assert "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy" in addrs
 
 
 def test_extract_pgp_keys():
-    block = '-----BEGIN PGP PUBLIC KEY BLOCK-----\nabc\n-----END PGP PUBLIC KEY BLOCK-----'
-    html = f'<pre>{block}</pre>'
+    """PGP key blocks are extracted."""
+    block = (
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\nabc\n-----END PGP PUBLIC KEY BLOCK-----"
+    )
+    html = f"<pre>{block}</pre>"
     keys = extract_pgp_keys(html)
     assert keys == [block]
 
 
 def test_extract_emails_and_ids():
-    html = 'Email me at user@example.com UA-1234-5'
+    """Emails and Google Analytics IDs are extracted."""
+    html = "Email me at user@example.com UA-1234-5"
     result = extract_emails_and_ids(html)
-    assert result['emails'] == ['user@example.com']
-    assert result['google_analytics_ids'] == ['UA-1234-5']
+    assert result["emails"] == ["user@example.com"]
+    assert result["google_analytics_ids"] == ["UA-1234-5"]
 
 
 def test_extract_metadata():
-    headers = {'Server': 'Apache', 'X-Powered-By': 'PHP', 'Other': 'value'}
+    """Only relevant headers are kept."""
+    headers = {"Server": "Apache", "X-Powered-By": "PHP", "Other": "value"}
     meta = extract_metadata(headers)
-    assert meta == {'Server': 'Apache', 'X-Powered-By': 'PHP'}
-
-
+    assert meta == {"Server": "Apache", "X-Powered-By": "PHP"}

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,22 +1,25 @@
+"""Tests for service scanning functionality."""
+
 import main
 
 
 def test_scan_service(monkeypatch):
+    """Verify that scan_service aggregates data correctly."""
     html = "<html></html>"
 
-    def fake_fetch_html_via_tor(url, timeout=10):
+    def fake_fetch_html_via_tor(_url, _timeout=10):
         return html, {"Server": "Apache"}
 
-    def fake_check_common_files(url, timeout=10):
+    def fake_check_common_files(_url, _timeout=10):
         return [{"path": "/admin", "status": 200}]
 
-    def fake_extract_cert_info(host, timeout=10):
+    def fake_extract_cert_info(_host, _timeout=10):
         return {"subject": []}
 
-    def fake_scan_protocols(host, timeout=10):
+    def fake_scan_protocols(_host, _timeout=10):
         return {"ssh_info": {"ssh_banner": "OpenSSH"}}
 
-    def fake_extract_exif_data_from_images(html, base, timeout=5):
+    def fake_extract_exif_data_from_images(_html, _base, _timeout=5):
         return []
 
     def fake_fetch_tor_descriptor():
@@ -42,10 +45,13 @@ def test_scan_service(monkeypatch):
 
 
 def test_fetch_tor_descriptor_cached(monkeypatch):
+    """Ensure cached descriptor prevents repeated downloads."""
     calls = []
 
     def fake_get_server_descriptors():
-        class Desc:
+        class Desc:  # pylint: disable=too-few-public-methods
+            """Minimal descriptor."""
+
             nickname = "x"
             published = "now"
             platform = "p"


### PR DESCRIPTION
## Summary
- add tests for Tor session creation, checking common files, and EXIF extraction
- format existing tests with `black`
- ensure code passes `pylint`

## Testing
- `pytest -q`
- `pylint main.py tests/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6849b1bcfca88321be9a1b9191590fd7