### PR TITLE
Handle missing Tor descriptors

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,14 +194,17 @@ def fetch_tor_descriptor():
     """Fetch the first available Tor relay descriptor."""
 
     try:
-        desc = list(stem.descriptor.remote.get_server_descriptors())[0]
+        descriptors = list(stem.descriptor.remote.get_server_descriptors())
+        if not descriptors:
+            raise IndexError("no descriptors")
+        desc = descriptors[0]
         return {
             "nickname": desc.nickname,
             "published": str(desc.published),
             "platform": desc.platform,
             "contact": desc.contact,
         }
-    except stem.DescriptorUnavailable as exc:  # type: ignore[attr-defined]
+    except (stem.DescriptorUnavailable, IndexError) as exc:  # type: ignore[attr-defined]
         return {"error": str(exc)}
 
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -69,3 +69,19 @@ def test_fetch_tor_descriptor_cached(monkeypatch):
     main.fetch_tor_descriptor()
     main.fetch_tor_descriptor()
     assert len(calls) == 1
+
+
+def test_fetch_tor_descriptor_empty(monkeypatch):
+    """Function should return an error if no descriptors are fetched."""
+
+    def fake_get_server_descriptors():
+        return []
+
+    monkeypatch.setattr(
+        main.stem.descriptor.remote,
+        "get_server_descriptors",
+        fake_get_server_descriptors,
+    )
+    main.fetch_tor_descriptor.cache_clear()
+    result = main.fetch_tor_descriptor()
+    assert "error" in result


### PR DESCRIPTION
## Summary
- ensure `fetch_tor_descriptor` gracefully handles missing descriptors
- test descriptor fetching when none are returned

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d6b69f108321a3ac574ced2697a2