### PR TITLE
Handle missing proxy env vars

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,8 +24,8 @@ def get_tor_session():
 
     global _TOR_SESSION  # pylint: disable=global-statement
     if _TOR_SESSION is None:
-        host = os.getenv("TOR_PROXY_HOST", "127.0.0.1")
-        port = os.getenv("TOR_PROXY_PORT", "9050")
+        host = os.getenv("TOR_PROXY_HOST") or "127.0.0.1"
+        port = os.getenv("TOR_PROXY_PORT") or "9050"
         session = requests.Session()
         proxies = {
             "http": f"socks5h://{host}:{port}",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -93,3 +93,24 @@ def test_extract_exif_data_from_images(monkeypatch):
 
     result = main.extract_exif_data_from_images(html, "http://a.onion")
     assert result == [{"src": "http://a.onion/img.png", "exif": {1: 2}}]
+
+
+def test_get_tor_session_defaults(monkeypatch):
+    """Default proxy values are used when env vars are absent or empty."""
+    calls = []
+
+    class FakeSession:  # pylint: disable=too-few-public-methods
+        def __init__(self):
+            calls.append(1)
+            self.proxies = {}
+            self.headers = {}
+
+    monkeypatch.setattr(main.requests, "Session", lambda: FakeSession())
+    monkeypatch.delenv("TOR_PROXY_HOST", raising=False)
+    monkeypatch.delenv("TOR_PROXY_PORT", raising=False)
+    main._TOR_SESSION = None  # pylint: disable=protected-access
+
+    session = main.get_tor_session()
+
+    assert session.proxies["http"] == "socks5h://127.0.0.1:9050"
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- keep defaults for Tor SOCKS proxy when env vars are unset or empty
- test fallback to default proxy values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e024fbe483219d7e012c582cee8e