### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install pylint black pytest
+      - run: black . --check
+      - run: pylint main.py tests/*.py
+      - run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PythonOnionScan
 
+[![Tests](https://github.com/OWNER/REPO/actions/workflows/tests.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/tests.yml)
+
 A modern Python3 port of the original [OnionScan](https://github.com/s-rah/onionscan) by [@s-rah](https://github.com/s-rah).
 
 This tool allows you to scan `.onion` hidden services for common misconfigurations, metadata leaks, and protocol exposure vulnerabilities—via the Tor network.


### PR DESCRIPTION
## Summary
- run Python tests in CI with `black`, `pylint`, and `pytest`
- show build status badge in the README

## Testing
- `black . --check`
- `pylint main.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5e0146888321888eaefd062a3e13