### PR TITLE
Route raw sockets via Tor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This tool allows you to scan `.onion` hidden services for common misconfiguratio
 * 🔍 Detect common exposed files (`/.git`, `/admin`, etc.)
 * 🛡️ Extract SSL certificate metadata
 * 🧠 Protocol banner scanning (SSH, FTP, SMTP, XMPP, Bitcoin)
+* 🌐 DNS lookups for banners and certificates are routed through the Tor proxy
 * 🔗 Parse and list all linked `.onion` addresses
 * 🪙 Extract embedded Bitcoin addresses
 * 🔐 PGP block scanner


### PR DESCRIPTION
## Summary
- proxy DNS lookups for banner and TLS checks through Tor
- document proxied DNS in README

## Testing
- `black . --check`
- `pylint main.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687657f0b3dc8321b1f8f18f117476e1