### PR TITLE
Add CLI options for proxy address

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ python main.py http://somedomain.onion --timeout 15 --output scan.json
 ```
 
 The script looks for `TOR_PROXY_HOST` and `TOR_PROXY_PORT` environment
-variables to configure the SOCKS proxy. If they are not set, it defaults to
-`127.0.0.1` and port `9050`. If `TOR_PROXY_PORT` is non-numeric, `9050` is used.
+variables to configure the SOCKS proxy. You can also provide `--proxy-host` and
+`--proxy-port` on the command line to override these. If no values are supplied,
+it defaults to `127.0.0.1` and port `9050`. Non-numeric ports fall back to
+`9050`.
 
 Options:
 
 * `--timeout` — custom timeout in seconds (default: 10)
 * `--output` — path to save report JSON (default: `scan_report.json`)
+* `--proxy-host` — Tor proxy host (overrides `TOR_PROXY_HOST`)
+* `--proxy-port` — Tor proxy port (overrides `TOR_PROXY_PORT`)
 
 ---
 

--- a/docs/wiki/CodebaseOverview.md
+++ b/docs/wiki/CodebaseOverview.md
@@ -53,9 +53,10 @@ Dependencies include `requests`, `PySocks`, `Pillow`, `BeautifulSoup`, and `Stem
 The scanner logic is contained in `main.py`.
 
 1. **Tor Connection Setup** – `fetch_html_via_tor()` configures a SOCKS proxy
-   using `TOR_PROXY_HOST` and `TOR_PROXY_PORT` environment variables. When they
-   are unset, defaults of `127.0.0.1` and `9050` are used. A non-numeric
-   `TOR_PROXY_PORT` also falls back to `9050`.
+   using `--proxy-host`/`--proxy-port` or the `TOR_PROXY_HOST` and
+   `TOR_PROXY_PORT` environment variables. When no values are provided, defaults
+   of `127.0.0.1` and `9050` are used. A non-numeric `TOR_PROXY_PORT` also falls
+   back to `9050`.
 2. **Scanning Helpers** – functions like `check_common_files()` and `scan_protocols()` search for exposed paths and capture banners from common service ports.
 3. **`scan_service()` Workflow** – orchestrates HTML fetching, certificate extraction, protocol checks, and metadata parsing. Results are collected in a dictionary.
 4. **Command-Line Entry** – when invoked directly, the script accepts either a `.onion` URL or a text file of targets. The output is saved to a JSON report.
@@ -67,6 +68,8 @@ python main.py http://example.onion --timeout 15 --output scan.json
 ```
 
 Run this with a local Tor SOCKS proxy (typically `127.0.0.1:9050`) running.
+You can point the scanner at a different proxy using `--proxy-host` and
+`--proxy-port` or the matching environment variables.
 
 ## Points of Interest & Next Steps
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -59,9 +59,9 @@ python main.py http://somedomain.onion --timeout 15 --output scan.json
 * `--output` specifies the JSON file to write results to (default: `scan_report.json`)
 
 Make sure you have a Tor SOCKS proxy running locally, typically on `127.0.0.1:9050`.
-The proxy address can also be customized via the `TOR_PROXY_HOST` and
-`TOR_PROXY_PORT` environment variables. If `TOR_PROXY_PORT` is not numeric,
-`9050` is used.
+The proxy address can also be customized via `--proxy-host` and `--proxy-port`
+command-line options or the `TOR_PROXY_HOST` and `TOR_PROXY_PORT` environment
+variables. If the port is missing or non-numeric, `9050` is used.
 
 ## Next Steps
 

--- a/main.py
+++ b/main.py
@@ -18,12 +18,16 @@ import stem.descriptor.remote
 
 _TOR_SESSION = None
 
+# Optional override for the Tor proxy address configured via CLI
+PROXY_HOST = None
+PROXY_PORT = None
+
 
 def _get_proxy_config():
     """Return Tor proxy host and port, falling back to defaults."""
 
-    host = os.environ.get("TOR_PROXY_HOST")
-    port = os.environ.get("TOR_PROXY_PORT")
+    host = PROXY_HOST or os.environ.get("TOR_PROXY_HOST")
+    port = PROXY_PORT or os.environ.get("TOR_PROXY_PORT")
 
     if not host:
         host = "127.0.0.1"
@@ -295,7 +299,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--timeout", help="Request timeout in seconds", type=int, default=10
     )
+    parser.add_argument("--proxy-host", help="Tor proxy host")
+    parser.add_argument("--proxy-port", help="Tor proxy port")
     args = parser.parse_args()
+
+    # Override proxy settings if provided on the command line
+    if args.proxy_host:
+        PROXY_HOST = args.proxy_host
+    if args.proxy_port:
+        PROXY_PORT = args.proxy_port
 
     urls = []
     if args.onion.endswith(".txt") and os.path.exists(args.onion):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,6 +66,25 @@ def test_get_proxy_config_invalid_port(monkeypatch):
     assert port == "9050"
 
 
+def test_get_proxy_config_cli_override(monkeypatch):
+    """Command-line overrides should take precedence over env vars."""
+
+    monkeypatch.setenv("TOR_PROXY_HOST", "envhost")
+    monkeypatch.setenv("TOR_PROXY_PORT", "1111")
+    monkeypatch.setattr(main, "PROXY_HOST", "cli_host", raising=False)
+    monkeypatch.setattr(main, "PROXY_PORT", "2222", raising=False)
+
+    host, port = main._get_proxy_config()  # pylint: disable=protected-access
+
+    assert host == "cli_host"
+    assert port == "2222"
+
+    monkeypatch.setattr(main, "PROXY_HOST", None, raising=False)
+    monkeypatch.setattr(main, "PROXY_PORT", None, raising=False)
+    monkeypatch.delenv("TOR_PROXY_HOST", raising=False)
+    monkeypatch.delenv("TOR_PROXY_PORT", raising=False)
+
+
 def test_check_common_files(monkeypatch):
     """Check that known files are detected properly."""
 


### PR DESCRIPTION
## Summary
- allow `--proxy-host` and `--proxy-port` arguments
- document proxy CLI overrides in README and wiki docs
- test command-line proxy overrides

## Testing
- `black . --check`
- `pylint main.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877cea3be08832196a1de0ef0fe0808