### PR TITLE
Handle closed ports

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,6 +127,8 @@ def scan_banner(host, port, label, timeout=10):
             banner = sock.recv(1024).decode(errors="ignore").strip()
             return {f"{label}_banner": banner}
     except OSError as exc:
+        if "Connection refused" in str(exc):
+            return {"status": "closed"}
         return {"error": str(exc)}
 
 


### PR DESCRIPTION
## Summary
- improve `scan_banner` to return `{"status": "closed"}` for ports that refuse connections

## Testing
- `black . --check`
- `pylint main.py tests/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f0a287288321a1d0a96f4d201246